### PR TITLE
Downgrade AMP to support Python 3.6 by default

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -8,7 +8,7 @@ api_version: 1
 
 runtimes:
   - editor: Workbench
-    kernel: Python 3.8
+    kernel: Python 3.6
     edition: Standard
 
 tasks:

--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -18,6 +18,7 @@ tasks:
     script: cml/install_dependencies.py
     arguments: None
     short_summary: Create job to install dependencies.
+    kernel: python3
     cpu: 2
     memory: 4
     environment:
@@ -25,14 +26,15 @@ tasks:
 
   - type: run_job
     entity_label: install_dependencies
-    short_summary: Running install dependencies job. 
+    short_summary: Running install dependencies job.
 
   - type: start_application
-    short_summary: Starting Summarize. application 
+    short_summary: Starting Summarize. application
     name: Summarize.
     subdomain: summa
     script: apps/launch-summarize-app.py
     environment_variables:
       TASK_TYPE: START_APPLICATION
+    kernel: python3
     cpu: 2
     memory: 4

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This small library includes functionality to support the **Summarize.** applicat
 
 
 ## Installation
-The code and applications within were developed against Python 3.8.0., and are likely also to function with more recent versions of Python. 
+The code and applications within were developed against Python 3.6, and are likely also to function with more recent versions of Python. 
 
 To install dependencies, first create and activate a new virtual environment through your preferred means, then pip install from the requirements file. We recommend:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ attrs==21.2.0
 matplotlib==3.3.4
 cycler >= 0.10.0 # matplotlib dependency -- should be installed automatically but it wasn't when tested on eng cml cluster
 scikit-learn==0.24.2
-spacy==3.1.1
-spacy-transformers==1.0.3
-transformers==4.6.1 #4.92
-torch==1.9.0
-streamlit==0.87.0
+spacy==3.2.0
+spacy-transformers==1.1.2
+transformers==4.11.3
+torch==1.10.0
+streamlit==1.2.0
 networkx==2.5.1
 pytextrank==2.1.0
 wikipedia==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==21.2.0
-matplotlib==3.4.3
+matplotlib==3.3.4
 cycler >= 0.10.0 # matplotlib dependency -- should be installed automatically but it wasn't when tested on eng cml cluster
 scikit-learn==0.24.2
 spacy==3.1.1
@@ -7,7 +7,7 @@ spacy-transformers==1.0.3
 transformers==4.6.1 #4.92
 torch==1.9.0
 streamlit==0.87.0
-networkx==2.6.2
-pytextrank==3.2.1
+networkx==2.5.1
+pytextrank==2.1.0
 wikipedia==1.4.0
 -e .

--- a/summa/highlighting.py
+++ b/summa/highlighting.py
@@ -47,7 +47,8 @@ def match_most_text(text: str, original_text: str) -> List[str]:
     snippets = []
     texts = [text]
     originals = [original_text]
-    while longest := _find_longest_text(texts, originals):
+    longest = _find_longest_text(texts, originals)
+    while longest:
         # keep the longest
         snippets.append(longest)
         # remove longest from text and original_text
@@ -59,6 +60,7 @@ def match_most_text(text: str, original_text: str) -> List[str]:
             new_originals += text.split(longest)
         texts = new_texts
         originals = new_originals
+        longest = _find_longest_text(texts, originals)
     return snippets
 
 
@@ -87,7 +89,8 @@ def _find_longest_text(texts: List[str], original_texts: List[str]) -> Optional[
     candidates = []
     for text in texts:
         for original in original_texts:
-            if chunk := _find_longest_text_single(text, original):
+            chunk = _find_longest_text_single(text, original)
+            if chunk:
                 candidates.append(chunk)
     if candidates:
         return sorted(candidates, key=lambda x: len(x), reverse=True)[0]


### PR DESCRIPTION
There are two issues causing this AMP to fail tests on PvC. 

**Issue #1**

In the .project-metadata.yaml file, the two tasks (job and application) were both missing a ***kernel*** field and value. This is not a required field for Runtimes (which the AMP was developed on), but is necessary for engines. Therefore, when the AMP is run on PVC (engines only) or on PC (with engine selected), the AMP fails. This is a quick fix.

**Issue #2**

This AMP was developed for Python 3.8 while legacy engines only support Python 3.6. While this doesn't always cause a problem, in this case it did. The issue resides in the fact that some of the projects dependency versions are not supported by older versions of Python.

- matplotlib==3.3.4 is not available for Python 3.6 (up to 3.3.4 is)
- networkx==2.6.2 is not available for Python 3.6 (up to 2.5.1 is)
- pytextrank==3.2.1 is not available for Python 3.6 (up to 2.1.0 is)

Downgrading to these available versions works for the AMP on Python 3.6, but then causes incpompatibilies on Python 3.8. Therefore, the solution is to reconfigure the AMP to run on Python 3.6 by default so that package versions can remain consistent.

Downgrading to Python 3.6 means we lose access to new Python syntax used in the AMP including the walrus operator (sorry Melanie 😢 )...