### PR TITLE
/bugfix: Can't find model 'en_core_web_sm'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,10 @@ attrs==21.2.0
 matplotlib==3.3.4
 cycler >= 0.10.0 # matplotlib dependency -- should be installed automatically but it wasn't when tested on eng cml cluster
 scikit-learn==0.24.2
-spacy==3.2.0
+spacy==3.0.7
 spacy-transformers==1.1.2
 transformers==4.11.3
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz
 torch==1.10.0
 streamlit==1.2.0
 networkx==2.5.1


### PR DESCRIPTION
This PR fixes an error that traces back to model `en_core_web_sm` not been found with existing configuration. See error trace below.

- amends `requirements.txt`: Include installation of the respective required model
- amends `requirements.txt`: Change spacy version to most recent one compatible with newly installable model above.

```python
2021-12-17 15:03:43.901 Traceback (most recent call last):
  File "/home/cdsw/.local/lib/python3.6/site-packages/streamlit/script_runner.py", line 354, in _run_script
    exec(code, module.__dict__)
  File "/home/cdsw/CML_AMP_Summarize/apps/summarize-app.py", line 50, in <module>
    from st_model_wrappers import (
  File "apps/st_model_wrappers.py", line 43, in <module>
    from summa.models import neural_extractive as ne
  File "/home/cdsw/CML_AMP_Summarize/summa/models/neural_extractive.py", line 58, in <module>    nlp = spacy.load("en_core_web_sm")  # change to large at some point  File "/home/cdsw/.local/lib/python3.6/site-packages/spacy/__init__.py", line 52, in load
    name, vocab=vocab, disable=disable, exclude=exclude, config=config
  File "/home/cdsw/.local/lib/python3.6/site-packages/spacy/util.py", line 427, in load_model
    raise IOError(Errors.E050.format(name=name))
OSError: [E050] Can't find model 'en_core_web_sm'. It doesn't seem to be a Python package or a valid path to a data directory.
``` 